### PR TITLE
Fix reliable path loading

### DIFF
--- a/example/markdowns-peek.js
+++ b/example/markdowns-peek.js
@@ -4844,31 +4844,31 @@
 
       async loadDirectory() {
         const filesList = this.container.querySelector(`[class~="${this.prefix}files-list"]`);
-        
+
         try {
           const data = await this.fetchGitHubContents(this.path);
-          
+
           if (Array.isArray(data)) {
-            this.files = data.filter(file => 
-              file.type === 'file' && file.name.toLowerCase().endsWith('.md')
+            const normalizedPath = this.path.replace(/\/$/, '');
+            const prefix = normalizedPath ? normalizedPath + '/' : '';
+
+            const validPath = !normalizedPath || data.every(item =>
+              item.path && item.path.startsWith(prefix)
             );
-          } else {
-            this.files = [];
-          }
-          
-          if (this.path && this.path !== '') {
-            const filesInPath = this.files.filter(file => 
-              file.path && file.path.startsWith(this.path + '/')
-            );
-            
-            if (filesInPath.length === 0) {
+
+            if (!validPath) {
               setTimeout(() => {
                 this.loadDirectory();
               }, 1000);
               return;
             }
-            
-            this.files = filesInPath;
+
+            this.files = data.filter(file =>
+              file.type === 'file' && file.name.toLowerCase().endsWith('.md') &&
+              (!normalizedPath || file.path.startsWith(prefix))
+            );
+          } else {
+            this.files = [];
           }
           
           if (this.sortAlphabetically) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdowns-peek",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdowns-peek",
-      "version": "1.0.0",
+      "version": "1.0.8",
       "license": "LGPL-2.1",
       "dependencies": {
         "dompurify": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdowns-peek",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A beautiful GitHub Markdown file viewer for web applications",
   "main": "dist/markdowns-peek.js",
   "module": "dist/markdowns-peek.esm.js",

--- a/src/markdowns-peek.js
+++ b/src/markdowns-peek.js
@@ -423,31 +423,31 @@ class MarkdownsPeek {
 
   async loadDirectory() {
     const filesList = this.container.querySelector(`[class~="${this.prefix}files-list"]`);
-    
+
     try {
       const data = await this.fetchGitHubContents(this.path);
-      
+
       if (Array.isArray(data)) {
-        this.files = data.filter(file => 
-          file.type === 'file' && file.name.toLowerCase().endsWith('.md')
+        const normalizedPath = this.path.replace(/\/$/, '');
+        const prefix = normalizedPath ? normalizedPath + '/' : '';
+
+        const validPath = !normalizedPath || data.every(item =>
+          item.path && item.path.startsWith(prefix)
         );
-      } else {
-        this.files = [];
-      }
-      
-      if (this.path && this.path !== '') {
-        const filesInPath = this.files.filter(file => 
-          file.path && file.path.startsWith(this.path + '/')
-        );
-        
-        if (filesInPath.length === 0) {
+
+        if (!validPath) {
           setTimeout(() => {
             this.loadDirectory();
           }, 1000);
           return;
         }
-        
-        this.files = filesInPath;
+
+        this.files = data.filter(file =>
+          file.type === 'file' && file.name.toLowerCase().endsWith('.md') &&
+          (!normalizedPath || file.path.startsWith(prefix))
+        );
+      } else {
+        this.files = [];
       }
       
       if (this.sortAlphabetically) {


### PR DESCRIPTION
## Summary
- ensure `loadDirectory` validates data path prefix
- retry fetching if GitHub response doesn't match specified path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7355d8e4832c9bde61e4ab910d42