### PR TITLE
Add author parsing with proper github io deploy and localhost serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
+.serve-temp/
 
 # Logs
 logs/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ npm run dev
 
 # Serve examples
 npm run serve
+# After running serve, open http://localhost:3000/markdowns-peek in your browser
 ```
 
 ## GitHub Actions

--- a/example/404.html
+++ b/example/404.html
@@ -27,7 +27,7 @@
   <div id="markdown-viewer-blog"></div>
   <div id="markdown-viewer-articles"></div>
 
-  <script src="/markdowns-peek.js"></script>
+  <script src="/markdowns-peek/markdowns-peek.js"></script>
   <script>
     const commonConfig = {
       height: '100%',
@@ -52,7 +52,7 @@
       theme: 'dark',
       owner: 'PeterPorzuczek',
       repo: 'echo',
-      basePath: 'blog'
+      basePath: 'markdowns-peek/blog'
     });
     
     new MarkdownsPeek({
@@ -62,7 +62,7 @@
       owner: 'PeterPorzuczek',
       repo: 'articles',
       path: 'articles-md',
-      basePath: 'articles'
+      basePath: 'markdowns-peek/articles'
     });
   </script>
 

--- a/example/custom-prefix.html
+++ b/example/custom-prefix.html
@@ -72,7 +72,7 @@
         </div>
     </div>
 
-    <script src="markdowns-peek.js"></script>
+    <script src="./markdowns-peek.js"></script>
 
     <script>        
         // Default random prefix
@@ -80,7 +80,8 @@
             containerId: 'markdowns-peek',
             owner: 'facebook',
             repo: 'react',
-            theme: 'light'
+            theme: 'light',
+            loadFirstFileAutomatically: false
         });
         
         console.log('Viewer 1 prefix:', viewer1.prefix);
@@ -92,7 +93,8 @@
             repo: 'core',
             path: 'changelogs',
             theme: 'dark',
-            prefix: 'my-custom-'
+            prefix: 'my-custom-',
+            loadFirstFileAutomatically: false
         });
         
         console.log('Viewer 2 prefix:', viewer2.prefix);

--- a/example/custom-styles.html
+++ b/example/custom-styles.html
@@ -601,7 +601,7 @@
         </div>
     </div>
 
-    <script src="markdowns-peek.js"></script>
+    <script src="./markdowns-peek.js"></script>
 
     <script>
         new MarkdownsPeek({
@@ -610,7 +610,8 @@
             repo: 'react',
             theme: 'dark',
             prefix: 'en-',
-            disableStyles: true
+            disableStyles: true,
+            loadFirstFileAutomatically: false
         });
         
         new MarkdownsPeek({
@@ -619,7 +620,8 @@
             repo: 'core',
             theme: 'light',
             prefix: 'pl-',
-            disableStyles: true
+            disableStyles: true,
+            loadFirstFileAutomatically: false
         });
         
         new MarkdownsPeek({
@@ -628,7 +630,8 @@
             repo: 'angular',
             theme: 'light',
             prefix: 'vanilla-',
-            disableStyles: true
+            disableStyles: true,
+            loadFirstFileAutomatically: false
         });
     </script>
 </body>

--- a/example/custom-texts.html
+++ b/example/custom-texts.html
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    <script src="markdowns-peek.js"></script>
+    <script src="./markdowns-peek.js"></script>
 
     <script>
         
@@ -71,7 +71,8 @@
             repo: 'articles',
             path: 'articles-md',
             sortAlphabetically: 'true',
-            theme: 'light'
+            theme: 'light',
+            loadFirstFileAutomatically: false
         });
         
         // Custom Polish texts
@@ -82,6 +83,7 @@
             path: 'articles-md',
             sortAlphabetically: 'true',
             theme: 'dark',
+            loadFirstFileAutomatically: false,
             texts: {
                 menu: 'MENU',
                 files: 'PLIKI',
@@ -100,6 +102,7 @@
             repo: 'articles',
             path: 'articles-md',
             theme: 'light',
+            loadFirstFileAutomatically: false,
             prefix: 'vanilla-',
             texts: {
                 menu: '',

--- a/example/index.html
+++ b/example/index.html
@@ -136,14 +136,14 @@
                     <input type="text" id="repo" placeholder="Repository name" value="echo">
                     <input type="text" id="path" placeholder="Path (optional)" value="">
                     <input type="text" id="branch" placeholder="Branch (optional)" value="">
-                    <input type="text" id="basePath" placeholder="Base path (optional)" value="blog">
+                    <input type="text" id="basePath" placeholder="Base path (optional)" value="markdowns-peek/blog">
                 </div>
                 
                 <div class="examples">
-                    <button class="example-btn" onclick="loadExample('PeterPorzuczek', 'echo', '/', 'main', 'blog')">
+                    <button class="example-btn" onclick="loadExample('PeterPorzuczek', 'echo', '/', 'main', 'markdowns-peek/blog')">
                         My Blog
                     </button>
-                    <button class="example-btn" onclick="loadExample('PeterPorzuczek', 'articles', 'articles-md', 'main', 'articles')">
+                    <button class="example-btn" onclick="loadExample('PeterPorzuczek', 'articles', 'articles-md', 'main', 'markdowns-peek/articles')">
                         My articles
                     </button>
                     <button class="example-btn" onclick="loadExample('vuejs', 'core', 'changelogs', 'main', '')">
@@ -164,7 +164,7 @@
         <div id="markdown-viewer"></div>
     </div>
 
-    <script src="markdowns-peek.js"></script>
+    <script src="/markdowns-peek/markdowns-peek.js"></script>
     
     <script>
         // Initialize the viewer
@@ -172,7 +172,7 @@
             containerId: 'markdown-viewer',
             owner: 'PeterPorzuczek',
             repo: 'echo',
-            basePath: "blog",
+            basePath: "markdowns-peek/blog",
             theme: 'light',
             token: '',
             loadFirstFileAutomatically: false  // Don't auto-load on homepage - wait for user to click

--- a/example/markdowns-peek.js
+++ b/example/markdowns-peek.js
@@ -4481,7 +4481,8 @@
       error: 'ERROR: ',
       noFiles: 'NO FILES FOUND',
       minRead: 'MIN READ',
-      notFound: 'ARTICLE NOT FOUND'
+      notFound: 'ARTICLE NOT FOUND',
+      author: 'AUTHOR'
     };
 
     const generateRandomChars = (length = 8) => {
@@ -4525,13 +4526,14 @@
   </div>
 `;
 
-    const createFileContentTemplate = (title, readingTime, fileSize, sanitizedHtml, texts, prefix, htmlUrl, articleDate, articleUrl) => `
+    const createFileContentTemplate = (title, readingTime, fileSize, sanitizedHtml, texts, prefix, htmlUrl, articleDate, articleUrl, articleAuthor) => `
   <header class="${prefix}header">
     <h1 class="${prefix}title" title="${title}">${title}</h1>
     <div class="${prefix}header-row">
       <div class="${prefix}info">
         <span>${readingTime} ${texts.minRead}</span>
         ${articleDate ? `<span>${articleDate}</span>` : `<span>${fileSize}</span>`}
+        ${articleAuthor ? `<span>${texts.author}: ${articleAuthor}</span>` : ''}
       </div>
       <div class="${prefix}header-actions">
         ${articleUrl ? `
@@ -4994,6 +4996,12 @@
           metadata.date = dateMatch[1].replace(/[\u2010-\u2015]/g, '-');
         }
         
+        // Parse author - support both with and without quotes
+        const authorMatch = metadataText.match(/author:\s*["']?([^"'\n]+)["']?/);
+        if (authorMatch) {
+          metadata.author = authorMatch[1].trim();
+        }
+        
         // Parse title
         const titleMatch = metadataText.match(/title:\s*["']([^"']+)["']/);
         if (titleMatch) {
@@ -5346,6 +5354,7 @@
           // Parse metadata from HTML comment
           const metadata = this.parseMetadataFromComment(textContent);
           const articleDate = metadata && metadata.date ? this.formatDate(metadata.date) : null;
+          const articleAuthor = metadata && metadata.author ? metadata.author : null;
           
           const readingTime = this.calculateReadingTime(textContent);
           const htmlContent = marked(textContent);
@@ -5380,7 +5389,8 @@
             this.prefix,
             this.showGitHubLink ? data.html_url : null,
             articleDate,
-            fullArticleUrl
+            fullArticleUrl,
+            articleAuthor
           );
           this.updateTextWidth();
           const body = content.querySelector(`[class~="${this.prefix}body"]`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdowns-peek",
-  "version": "1.0.8",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdowns-peek",
-      "version": "1.0.8",
+      "version": "1.0.18",
       "license": "LGPL-2.1",
       "dependencies": {
         "dompurify": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdowns-peek",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "A beautiful GitHub Markdown file viewer for web applications",
   "main": "dist/markdowns-peek.js",
   "module": "dist/markdowns-peek.esm.js",
@@ -17,11 +17,11 @@
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
-
     "deploy": "gh-pages -d example",
     "predeploy": "npm run build && rimraf example/markdowns-peek.js && copyfiles -f dist/markdowns-peek.js example",
-    "preserve": "npm run build && rimraf example/markdowns-peek.js && copyfiles -f dist/markdowns-peek.js example",
-    "serve": "npx serve example"
+    "setup:serve": "npm run build && rimraf example/markdowns-peek.js && rimraf .serve-temp && copyfiles -f dist/markdowns-peek.js example && node -e \"const fs=require('fs');const path=require('path');fs.mkdirSync('.serve-temp/markdowns-peek',{recursive:true});fs.readdirSync('example').forEach(f=>fs.cpSync(path.join('example',f),path.join('.serve-temp/markdowns-peek',f),{recursive:true}));fs.writeFileSync('.serve-temp/serve.json',JSON.stringify({cleanUrls:false,directoryListing:false,rewrites:[{source:'/markdowns-peek',destination:'/markdowns-peek/index.html'},{source:'/markdowns-peek/',destination:'/markdowns-peek/index.html'},{source:'/markdowns-peek/blog/**',destination:'/markdowns-peek/404.html'},{source:'/markdowns-peek/articles/**',destination:'/markdowns-peek/404.html'}]},null,2));\"",
+    "serve": "npm run setup:serve && npx serve .serve-temp -p 3000",
+    "postserve": "rimraf .serve-temp"
   },
   "keywords": [
     "github",

--- a/src/markdowns-peek.js
+++ b/src/markdowns-peek.js
@@ -408,6 +408,12 @@ class MarkdownsPeek {
       metadata.date = dateMatch[1].replace(/[\u2010-\u2015]/g, '-');
     }
     
+    // Parse author - support both with and without quotes
+    const authorMatch = metadataText.match(/author:\s*["']?([^"'\n]+)["']?/);
+    if (authorMatch) {
+      metadata.author = authorMatch[1].trim();
+    }
+    
     // Parse title
     const titleMatch = metadataText.match(/title:\s*["']([^"']+)["']/);
     if (titleMatch) {
@@ -760,6 +766,7 @@ class MarkdownsPeek {
       // Parse metadata from HTML comment
       const metadata = this.parseMetadataFromComment(textContent);
       const articleDate = metadata && metadata.date ? this.formatDate(metadata.date) : null;
+      const articleAuthor = metadata && metadata.author ? metadata.author : null;
       
       const readingTime = this.calculateReadingTime(textContent);
       const htmlContent = marked(textContent);
@@ -794,7 +801,8 @@ class MarkdownsPeek {
         this.prefix,
         this.showGitHubLink ? data.html_url : null,
         articleDate,
-        fullArticleUrl
+        fullArticleUrl,
+        articleAuthor
       );
       this.updateTextWidth();
       const body = content.querySelector(`[class~="${this.prefix}body"]`);

--- a/src/templates.js
+++ b/src/templates.js
@@ -27,13 +27,14 @@ export const createFileTemplate = (file, index, displayName, size, prefix) => `
   </div>
 `;
 
-export const createFileContentTemplate = (title, readingTime, fileSize, sanitizedHtml, texts, prefix, htmlUrl, articleDate, articleUrl) => `
+export const createFileContentTemplate = (title, readingTime, fileSize, sanitizedHtml, texts, prefix, htmlUrl, articleDate, articleUrl, articleAuthor) => `
   <header class="${prefix}header">
     <h1 class="${prefix}title" title="${title}">${title}</h1>
     <div class="${prefix}header-row">
       <div class="${prefix}info">
         <span>${readingTime} ${texts.minRead}</span>
         ${articleDate ? `<span>${articleDate}</span>` : `<span>${fileSize}</span>`}
+        ${articleAuthor ? `<span>${texts.author}: ${articleAuthor}</span>` : ''}
       </div>
       <div class="${prefix}header-actions">
         ${articleUrl ? `

--- a/src/texts.js
+++ b/src/texts.js
@@ -7,5 +7,6 @@ export const defaultTexts = {
   error: 'ERROR: ',
   noFiles: 'NO FILES FOUND',
   minRead: 'MIN READ',
-  notFound: 'ARTICLE NOT FOUND'
+  notFound: 'ARTICLE NOT FOUND',
+  author: 'AUTHOR'
 }; 

--- a/tests/__snapshots__/markdowns-peek-snapshots.steps.js.snap
+++ b/tests/__snapshots__/markdowns-peek-snapshots.steps.js.snap
@@ -6,6 +6,7 @@ exports[`MarkdownsPeek Snapshots Custom configuration HTML structure snapshot 1`
   "customConfig": true,
   "prefix": "custom-prefix",
   "texts": {
+    "author": "AUTHOR",
     "error": "Custom Error: ",
     "files": "FILES",
     "loading": "Custom Loading...",
@@ -24,6 +25,7 @@ exports[`MarkdownsPeek Snapshots Default HTML structure snapshot 1`] = `
   "prefix": "default-prefix",
   "styles": undefined,
   "texts": {
+    "author": "AUTHOR",
     "error": "ERROR: ",
     "files": "FILES",
     "loading": "LOADING...",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds author metadata parsing/rendering and reconfigures examples/serve to work under /markdowns-peek for GitHub Pages and localhost.
> 
> - **Core Library**
>   - Parse `author` from HTML comment metadata and surface it in the header (`texts.author` added).
>   - Extend `createFileContentTemplate(...)` to accept `articleAuthor` and render it when available.
>   - Update both `src/` and built `example/markdowns-peek.js` accordingly.
> - **Examples & Docs**
>   - Point scripts/assets and `basePath` to `/markdowns-peek/...` across `example/*.html` for GitHub Pages routing.
>   - Set `loadFirstFileAutomatically: false` in examples where appropriate.
>   - README: add localhost URL hint after `npm run serve`.
> - **Tooling**
>   - Replace `serve` flow with `.serve-temp` staging and rewrites for `/markdowns-peek` paths; add cleanup and ignore `.serve-temp/`.
>   - Bump version to `1.0.18`.
>   - Update Jest snapshots to include `author` in texts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58a8f3fd3cd82af3b4a8f7d192c7b014708e905a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->